### PR TITLE
Allow long message and context strings

### DIFF
--- a/src/Logger/Laravel/migrations/create_logs_table.php
+++ b/src/Logger/Laravel/migrations/create_logs_table.php
@@ -22,8 +22,8 @@ class CreateLogsTable extends Migration
                 $table->string('channel')->index();
                 $table->string('level')->index();
                 $table->string('level_name');
-                $table->text('message');
-                $table->text('context');
+                $table->longText('message');
+                $table->longText('context');
 
                 $table->integer('remote_addr')->nullable()->unsigned();
                 $table->string('user_agent')->nullable();


### PR DESCRIPTION
Without this change, a message or a context longer than 65,535 characters would cause a memory leak, due to a `QueryException` being thrown and then attempted to be logged.